### PR TITLE
Group repeated warning/errors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,7 +10,7 @@ const TEST_MESSAGES = {
   subject_period: "This subject line ends in a period.",
   empty_line: "This subject line is fine\nBut then I forgot the empty line separating the subject and the body.",
   all_errors: "this is a really long subject and it even ends in a period.\nNot to mention the missing empty line!",
-  valid:  "This is a valid message\n\nYou can tell because it meets all the criteria and the linter does not complain.",
+  valid: "This is a valid message\n\nYou can tell because it meets all the criteria and the linter does not complain.",
 }
 
 describe("commitLint()", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -256,4 +256,50 @@ describe("commitLint()", () => {
     expect(global.fail).toHaveBeenCalledWith("Please use more than one word in commit message.\n123456")
     expect(global.warn).not.toHaveBeenCalled()
   })
+
+  it("should group repeated errors together", () => {
+    global.danger = {
+      git: {
+        commits: [
+          {
+            message: TEST_MESSAGES.subject_cap,
+            sha: "sha1",
+          },
+          {
+            message: TEST_MESSAGES.subject_cap,
+            sha: "sha2",
+          },
+        ],
+      },
+    }
+
+    commitLint.check()
+
+    expect(global.fail).toHaveBeenCalledWith("Please start commit subject with capital letter.\nsha1\nsha2")
+    expect(global.warn).not.toHaveBeenCalled()
+  })
+
+  it("should group repeated warnings together", () => {
+    global.danger = {
+      git: {
+        commits: [
+          {
+            message: TEST_MESSAGES.empty_line,
+            sha: "sha1",
+          },
+          {
+            message: TEST_MESSAGES.empty_line,
+            sha: "sha2",
+          },
+        ],
+      },
+    }
+
+    commitLint.check({
+      warn: [CommitLintRuleName.empty_line],
+    })
+
+    expect(global.fail).not.toHaveBeenCalledWith()
+    expect(global.warn).toHaveBeenCalledWith("Please separate commit subject from body with newline.\nsha1\nsha2")
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Provides dev-time type structures for  `danger` - doesn't affect runtime.
-import {DangerDSLType} from "../node_modules/danger/distribution/dsl/DangerDSL"
+import { DangerDSLType } from "../node_modules/danger/distribution/dsl/DangerDSL"
 declare var danger: DangerDSLType
 declare function message(message: string): void
 declare function warn(message: string): void
@@ -13,18 +13,12 @@ import { SubjectWordsRule } from "./rules/SubjectWordsRule"
 import { CommitLintRuleName, CommitLintRuleNameUnion } from "./types"
 
 export interface CommitLintOptions {
-  warn?: true | Array<CommitLintRuleName|CommitLintRuleNameUnion>;
-  fail?: true | Array<CommitLintRuleName|CommitLintRuleNameUnion>;
-  disable?: true | Array<CommitLintRuleName|CommitLintRuleNameUnion>;
+  warn?: true | Array<CommitLintRuleName | CommitLintRuleNameUnion>
+  fail?: true | Array<CommitLintRuleName | CommitLintRuleNameUnion>
+  disable?: true | Array<CommitLintRuleName | CommitLintRuleNameUnion>
 }
 
-const rules = [
-  EmptyLineRule,
-  SubjectCapRule,
-  SubjectLengthRule,
-  SubjectPeriodRule,
-  SubjectWordsRule,
-]
+const rules = [EmptyLineRule, SubjectCapRule, SubjectLengthRule, SubjectPeriodRule, SubjectWordsRule]
 
 /**
  * This is a Danger Plugin that ensures nice and tidy commit messages.
@@ -35,10 +29,10 @@ export function check(options: CommitLintOptions = {}) {
     return
   }
 
-  rules.forEach((ruleClass) => {
-    danger.git.commits.forEach((commit) => {
+  rules.forEach(ruleClass => {
+    danger.git.commits.forEach(commit => {
       const [subject, emptyLine] = commit.message.split("\n")
-      const rule = new (ruleClass)()
+      const rule = new ruleClass()
 
       const error = rule.check({
         subject,

--- a/src/rules/CommitLintRule.ts
+++ b/src/rules/CommitLintRule.ts
@@ -2,5 +2,5 @@ import { CommitInfo, CommitLintRuleName } from "../types"
 
 export abstract class CommitLintRule {
   public abstract readonly name: CommitLintRuleName
-  public abstract check(info: CommitInfo): string|null
+  public abstract check(info: CommitInfo): string | null
 }

--- a/src/rules/CommitLintRule.ts
+++ b/src/rules/CommitLintRule.ts
@@ -2,5 +2,6 @@ import { CommitInfo, CommitLintRuleName } from "../types"
 
 export abstract class CommitLintRule {
   public abstract readonly name: CommitLintRuleName
-  public abstract check(info: CommitInfo): string | null
+  public abstract readonly message: string
+  public abstract check(info: CommitInfo): boolean
 }

--- a/src/rules/EmptyLineRule.ts
+++ b/src/rules/EmptyLineRule.ts
@@ -3,12 +3,9 @@ import { CommitLintRule } from "./CommitLintRule"
 
 export class EmptyLineRule extends CommitLintRule {
   name = CommitLintRuleName.empty_line
-  check(info: CommitInfo) {
-    const isFail = Boolean(info.emptyLine && info.emptyLine.length > 0)
-    if (isFail) {
-      return "Please separate commit subject from body with newline."
-    }
+  message = "Please separate commit subject from body with newline."
 
-    return null
+  check(info: CommitInfo) {
+    return Boolean(info.emptyLine && info.emptyLine.length > 0)
   }
 }

--- a/src/rules/SubjectCapRule.ts
+++ b/src/rules/SubjectCapRule.ts
@@ -3,12 +3,9 @@ import { CommitLintRule } from "./CommitLintRule"
 
 export class SubjectCapRule extends CommitLintRule {
   name = CommitLintRuleName.subject_cap
-  check(info: CommitInfo) {
-    const isFail = info.subject[0].toUpperCase() !== info.subject[0]
-    if (isFail) {
-      return "Please start commit subject with capital letter."
-    }
+  message = "Please start commit subject with capital letter."
 
-    return null
+  check(info: CommitInfo) {
+    return info.subject[0].toUpperCase() !== info.subject[0]
   }
 }

--- a/src/rules/SubjectLengthRule.ts
+++ b/src/rules/SubjectLengthRule.ts
@@ -3,12 +3,9 @@ import { CommitLintRule } from "./CommitLintRule"
 
 export class SubjectLengthRule extends CommitLintRule {
   name = CommitLintRuleName.subject_length
-  check(info: CommitInfo) {
-    const isFail = info.subject.length > 50
-    if (isFail) {
-      return "Please limit commit subject line to 50 characters."
-    }
+  message = "Please limit commit subject line to 50 characters."
 
-    return null
+  check(info: CommitInfo) {
+    return info.subject.length > 50
   }
 }

--- a/src/rules/SubjectPeriodRule.ts
+++ b/src/rules/SubjectPeriodRule.ts
@@ -3,12 +3,9 @@ import { CommitLintRule } from "./CommitLintRule"
 
 export class SubjectPeriodRule extends CommitLintRule {
   name = CommitLintRuleName.subject_period
-  check(info: CommitInfo) {
-    const isFail = info.subject[info.subject.length - 1] === "."
-    if (isFail) {
-      return "Please remove period from end of commit subject line."
-    }
+  message = "Please remove period from end of commit subject line."
 
-    return null
+  check(info: CommitInfo) {
+    return info.subject[info.subject.length - 1] === "."
   }
 }

--- a/src/rules/SubjectWordsRule.ts
+++ b/src/rules/SubjectWordsRule.ts
@@ -3,12 +3,9 @@ import { CommitLintRule } from "./CommitLintRule"
 
 export class SubjectWordsRule extends CommitLintRule {
   name = CommitLintRuleName.subject_words
-  check(info: CommitInfo) {
-    const isFail = info.subject.trim().split(" ").length < 2
-    if (isFail) {
-      return "Please use more than one word in commit message."
-    }
+  message = "Please use more than one word in commit message."
 
-    return null
+  check(info: CommitInfo) {
+    return info.subject.trim().split(" ").length < 2
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export enum CommitLintRuleName {
 export type CommitLintRuleNameUnion = keyof typeof CommitLintRuleName
 
 export interface CommitInfo {
-  subject: string;
-  emptyLine: string;
-  sha: string;
+  subject: string
+  emptyLine: string
+  sha: string
 }


### PR DESCRIPTION
Changes
><table>
>  <thead>
>    <tr>
>      <th width="50"></th>
>      <th width="100%" data-danger-table="true">Warnings</th>
>    </tr>
>  </thead>
>  <tbody><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit1</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit2</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit3</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit4</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit5</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit6</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit7</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit8</td>
>    </tr>
>  
><tr>
>      <td>:warning:</td>
>      <td>Please start commit subject with capital letter. commit9</td>
>    </tr>
>  </tbody>
></table>

to

><table>
>  <thead>
>    <tr>
>      <th width="50"></th>
>      <th width="100%" data-danger-table="true">Warnings</th>
>    </tr>
>  </thead>
>  <tbody><tr>
>      <td>:warning:</td>
>      <td>Please start commit subjects with capital letter. <br />
>  commit1  commit2  commit3  commit4  commit5  commit6  commit7  commit8  commit9
></td>
>    </tr>
>  </tbody>
></table>

I have also opened a PR for the ruby version over at https://github.com/jonallured/danger-commit_lint/pull/27

Let me know what you think and if there's anything I need to clean up before you think this is ready for merging. :+1: